### PR TITLE
Added Screenly as OS alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ auf Raspberry Pi. Die Nutzung mit einem einzigen Client/Player/Monitor ist
 kostenlos. Damit eignet sich Yodeck evtl. für kleine Büros.
 
 [`docs/yodeck.md`](https://github.com/netzbegruenung/schaufenster/blob/master/docs/yodeck.md)
+
+### Screenly
+
+OpenSource alternative zu Yodeck. Sollte ähnlichen Umfang haben wie Yodeck, aber durch OS flexibler.
+Beschreibung folgt. 
+
+https://www.screenly.io/ose/


### PR DESCRIPTION
Ich denke Screenly is generell etwas bekannter, hat falls benötigt ebenfalls kommerziellen Support, lässt sich dank OpenSource-Lizenz mit minimalem Aufwand aber auch komplett losgelöst nutzen und ggf. sogar in einer eigenen "grünen" Version mit Voreinstellungen verteilen.